### PR TITLE
Move @types dependency to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "typescript"
   ],
   "dependencies": {
-    "@types/react": "^16.8.12",
     "call-hooks": "^1.0.0",
     "deep-object-diff": "^1.1.0",
     "is-shallow-equal": "^1.0.1",
@@ -68,6 +67,7 @@
     "react": ">=16.8"
   },
   "devDependencies": {
+    "@types/react": "^16.8.12",
     "ava": "^1.4.1",
     "ava-spec": "^1.1.1",
     "awesome-typescript-loader": "^5.2.1",


### PR DESCRIPTION
I use this awesome library as a peerDependency of my library and TS compiler complains about duplicate @types/react definitions caused by being installed in overstated and my node_modules.

```bash
node_modules/@types/react/index.d.ts:2817:14 - error TS2300: Duplicate identifier 'LibraryManagedAttributes'.

2817         type LibraryManagedAttributes<C, P> = C extends React.MemoExoticComponent<infer T> | React.LazyExoticComponent<infer T>
                  ~~~~~~~~~~~~~~~~~~~~~~~~

  node_modules/overstated/node_modules/@types/react/index.d.ts:2818:14
    2818         type LibraryManagedAttributes<C, P> = C extends React.MemoExoticComponent<infer T> | React.LazyExoticComponent<infer T>
                      ~~~~~~~~~~~~~~~~~~~~~~~~
    'LibraryManagedAttributes' was also declared here.

node_modules/@types/react/index.d.ts:2881:13 - error TS2717: Subsequent property declarations must have the same type.  Property 'iframe' must be of type 'DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement>', but here has type 'DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement>'.

2881             iframe: React.DetailedHTMLProps<React.IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement>;
                 ~~~~~~

node_modules/overstated/node_modules/@types/react/index.d.ts:2818:14 - error TS2300: Duplicate identifier 'LibraryManagedAttributes'.

2818         type LibraryManagedAttributes<C, P> = C extends React.MemoExoticComponent<infer T> | React.LazyExoticComponent<infer T>
                  ~~~~~~~~~~~~~~~~~~~~~~~~

  node_modules/@types/react/index.d.ts:2817:14
    2817         type LibraryManagedAttributes<C, P> = C extends React.MemoExoticComponent<infer T> | React.LazyExoticComponent<infer T>
                      ~~~~~~~~~~~~~~~~~~~~~~~~
    'LibraryManagedAttributes' was also declared here.
```